### PR TITLE
Add the `hasTimedOut` method

### DIFF
--- a/Stream.php
+++ b/Stream.php
@@ -438,6 +438,20 @@ abstract class Stream implements Core\Event\Listenable
     }
 
     /**
+     * Check whether the connection has timed out or not.
+     * This is basically a shortcut of `getStreamMetaData` + the `timed_out`
+     * index, but the resulting code is more readable.
+     *
+     * @return bool
+     */
+    public function hasTimedOut()
+    {
+        $metaData = $this->getStreamMetaData();
+
+        return true === $metaData['timed_out'];
+    }
+
+    /**
      * Set blocking/non-blocking mode.
      *
      * @param   bool    $mode    Blocking mode.


### PR DESCRIPTION
To check whether a connection has timed out, we need to call the
`getStreamMetaData` method which returns an array, and then check the
value of the `timed_out` index in this array. The resulting code is:

    $metaData = $connection->getStreamMetaData();

    if (true === $metaData['timed_out']) {
        // …
    }

In some case, we need to check the time out value very often. In order
to have a better readability of the code, we introduce the `hasTimeOut`
shortcut method. The resulting code is then:

    if (true === $connection->hasTimedOut()) {
        // …
    }

Much better 😀.