### PR TITLE
Change the visibility of `getStream` to `public`

### DIFF
--- a/Stream.php
+++ b/Stream.php
@@ -347,7 +347,7 @@ abstract class Stream implements Core\Event\Listenable
      *
      * @return  resource
      */
-    protected function getStream()
+    public function getStream()
     {
         if (empty($this->_bucket)) {
             return null;


### PR DESCRIPTION
Because sometimes, we would like to access to the PHP resource. This was protected for several “security” reasons but this is often blocking to not being able to access the PHP resource directly.