### PR TITLE
Avoid closing a closed stream

### DIFF
--- a/Stream.php
+++ b/Stream.php
@@ -625,6 +625,10 @@ abstract class Stream implements IStream\Stream, Event\Listenable
      */
     public function __destruct()
     {
+        if (false === $this->isOpened()) {
+            return;
+        }
+
         $this->close();
 
         return;


### PR DESCRIPTION
It should fix https://github.com/hoaproject/File/issues/25

For an unknown reason, when the Symfony Form instance is destructed the destructor of Stream is trying to close the stream. **But** the stream isn't opened anymore and it generates an error.

> fclose(): 16442 is not a valid stream resource

Checking that the stream is opened before trying to close it seems to _solve_ the problem