### PR TITLE
Compatibility with PHP 8

### DIFF
--- a/Source/Stream.php
+++ b/Source/Stream.php
@@ -155,7 +155,7 @@ abstract class Stream implements IStream\Stream, Event\Listenable
      * If the stream does not exist, try to open it by calling the
      * $handler->_open() method.
      */
-    final private static function &_getStream(
+    private static function &_getStream(
         string $streamName,
         Stream $handler,
         string $context = null


### PR DESCRIPTION
`final private` methods in PHP 8 throw a warning.