### PR TITLE
chore(php-compat): private method should not be final

### DIFF
--- a/Stream.php
+++ b/Stream.php
@@ -192,7 +192,7 @@ abstract class Stream implements IStream\Stream, Event\Listenable
      * @return  array
      * @throws  \Hoa\Stream\Exception
      */
-    final private static function &_getStream(
+    private static function &_getStream(
         $streamName,
         Stream $handler,
         $context = null


### PR DESCRIPTION
This Pull Request is not supposed to be merged, it’s the same as #30 but applied on the last release instead of master so it can be used easily in existing project migrating to php 8.

in your composer.json, add this entry to tell composer about the fork:

```json
    "repositories": [{
        "type": "vcs",
        "url": "https://github.com/mathroc/Stream.git"
    }],
```

and add (or update) the `hoa/stream` in your dependencies like this:

```json
        "hoa/stream": "dev-1.17.02.21-php8 as 1.17.02.21",
```

you can then run `composer update hoa/stream` to use hoa/stream in a php8 project without having the warning mentioned in #32 